### PR TITLE
removing the onsave alert; replace w/ tooltip

### DIFF
--- a/templates/project_config.html
+++ b/templates/project_config.html
@@ -41,7 +41,7 @@
   </div>
   
   <div class='savecode affix' data-spy="affix" data-offset-top="20">
-    <a id = "savecodebtn" href = "javascript://" class='btn btn-primary btn-large'>Save</a>
+    <a id = "savecodebtn" data-title='saved!' href = "javascript://" class='btn btn-primary btn-large'>Save</a>
   </div>
   <script>
  
@@ -68,10 +68,13 @@ $(function(){
 
     $.post('/custom/script', {url:repo, scripts:out}, function(res){
       if(res.errors) throw res.errors;
-      alert("Saved!")
+      $('#savecodebtn').tooltip('show');
+      setTimeout(function () {
+        $('#savecodebtn').tooltip('hide');
+      }, 500);
     })
 
-  })  
+  }).tooltip({trigger:'manual'}) 
 })
 
   </script>


### PR DESCRIPTION
friends don't let friends use `alert()` ;)

the tooltip disappears after 500ms
![screen shot 2013-07-12 at 10 57 51 pm](https://f.cloud.github.com/assets/112170/793333/5a6d0326-ebf8-11e2-8b47-56b48aa4fbcf.png)
