### PR TITLE
Ensure custom steps fail if any command fails

### DIFF
--- a/worker.js
+++ b/worker.js
@@ -26,7 +26,7 @@ function shellCommand(command) {
   }
   
   return {
-    command: 'sh',
-    args: ['-x', '-c', normalizedCommand]
+    command: 'bash',
+    args: ['-e', '-x', '-c', normalizedCommand]
   };
 }


### PR DESCRIPTION
This switches the shell to bash and passes the `-x` option to fail
the step if any command fails. This can be ignored with the following

```
command || true
```

This should resolve https://github.com/Strider-CD/strider/issues/358
