### PR TITLE
Enable access to job data through EJS

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   "license": "BSD",
   "readmeFilename": "README.md",
   "dependencies": {
+    "ejs": "^1.0.0",
     "gitane": "~0.3.1"
   },
   "strider": {

--- a/worker.js
+++ b/worker.js
@@ -1,20 +1,22 @@
 'use strict';
 
+var ejs = require('ejs');
+
 module.exports = {
-  init: function (config, context, done) {
+  init: function (config, job, context, done) {
     var config = config || {};
     
     done(null, {
-      environment: shellCommand(config.environment),
-      prepare: shellCommand(config.prepare),
-      test: shellCommand(config.test),
-      deploy: shellCommand(config.deploy),
-      cleanup: shellCommand(config.cleanup)
+      environment: shellCommand(config.environment, job),
+      prepare: shellCommand(config.prepare, job),
+      test: shellCommand(config.test, job),
+      deploy: shellCommand(config.deploy, job),
+      cleanup: shellCommand(config.cleanup, job)
     });
   }
 };
 
-function shellCommand(command) {
+function shellCommand(command, job) {
   if (!command) {
     return;
   }
@@ -24,9 +26,18 @@ function shellCommand(command) {
   if (!normalizedCommand.length) {
     return;
   }
+
+  var commandToExecute = compileScript(job, normalizedCommand);
   
   return {
     command: 'bash',
-    args: ['-e', '-x', '-c', normalizedCommand]
+    args: ['-e', '-x', '-c', commandToExecute]
   };
 }
+
+var compileScript = function(job, shellScript) {
+  var compiled = ejs.compile(shellScript,'utf-8');
+  var compiledScript = compiled(job);
+
+  return compiledScript;
+};


### PR DESCRIPTION
This uses the same approach used in strider-ssh-deploy. It enables you to use commands like `.scripts/deploy.sh <%= ref.branch %>`