### PR TITLE
Prevent non-comment hashes from getting mangled

### DIFF
--- a/worker.js
+++ b/worker.js
@@ -21,7 +21,11 @@ function shellCommand(command, shell, job) {
     return;
   }
   
-  var normalizedCommand = command.replace(/#[^\n]*/g, '').trim();
+  var normalizedCommand = command.split('\n').reduce(function (lines, line) {
+    line = line.replace(/^\s*#.*$/, '').trim();
+    if (line.length) lines.push(line);
+    return lines;
+  }, []).join('\n');
   
   if (!normalizedCommand.length) {
     return;


### PR DESCRIPTION
Bash uses `#` for variable text substitution: http://www.tldp.org/LDP/abs/html/string-manipulation.html

```bash
URL="http://example.com"
HOST="${URL#http*://}"   # HOST="example.com"
```

This PR fixes command normalization to consider non-comment uses of `#`. It assumes a comment is a line beginning with zero or more whitespace characters followed by a `#`.